### PR TITLE
Simplify system prompt for code completion

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ This would typically return something like:
 ````
 ```typescript
 function calculateArea(width: number, height: number): number {
-  return width * area;
+  return width * height;
 }
 ```
 ````
@@ -140,7 +140,7 @@ function calculateArea(width: number, height: number): number {
 When what I wanted is:
 
 ```
-area;
+height;
 ```
 
 Some common issues encountered in responses:

--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ I found the following techniques yielded good results:
 - Include an explicit cursor marker.
 - Provide explicit examples of bad output in the system prompt.
 - Use a lower temperature for more deterministic responses.
+- Using bold and caps for the word "**MUST**" makes a huge difference.
 
 Here's an example of how code is sent in the user prompt:
 

--- a/README.md
+++ b/README.md
@@ -79,6 +79,12 @@ Configure automatic idle completion:
 (setq gptel-autocomplete-idle-delay nil)
 ```
 
+Customize the system prompt used for completion requests:
+
+```elisp
+(setq gptel-autocomplete-system-prompt "Your custom system prompt here")
+```
+
 When available, `gptel-autocomplete` cancels any in-flight completion request before sending a newer one. This reduces unnecessary token usage during rapid typing while preserving the latest completion behavior. This optimization requires `gptel-abort` support with curl transport enabled (`gptel-use-curl`).
 
 Bind keys that are active only while ghost text is visible:

--- a/gptel-autocomplete.el
+++ b/gptel-autocomplete.el
@@ -282,7 +282,7 @@ function foo(a, b) {
 Output:
 ```
 █START_COMPLETION█
-{
+    if (a < b) {
         return a;
     }
     return b;

--- a/gptel-autocomplete.el
+++ b/gptel-autocomplete.el
@@ -263,14 +263,12 @@ If POSITION is nil, use point."
       (gptel-request
        prompt
        :system "/no_think
-You are a code completion assistant. Complete the code at █CURSOR█, inserting your response strictly between █START_COMPLETION█ and █END_COMPLETION█.
+You are a code completion assistant. Complete the code at █CURSOR█.
 
 REQUIREMENTS:
-1. *entire* output **MUST** be wrapped in triple backticks (\`\`\`).
-2. Start with █START_COMPLETION█ and end with █END_COMPLETION█ on their own lines.
-3. Replace █CURSOR█ with the appropriate code; do NOT repeat the █CURSOR█ token.
-4. Do NOT include any code that appears after █END_COMPLETION█ in the input.
-5. Be MINIMAL: 1-20 lines max. Most responses should be a single line.
+1. Output **MUST** be wrapped between █START_COMPLETION█ and █END_COMPLETION█ lines.
+2. Do not repeat the cursor or surrounding code.
+3. Be minimal (1-20 lines max, usually a single line).
 
 Example:
 Input:
@@ -284,7 +282,7 @@ function foo(a, b) {
 Output:
 ```
 █START_COMPLETION█
-    if (a < b) {
+{
         return a;
     }
     return b;

--- a/gptel-autocomplete.el
+++ b/gptel-autocomplete.el
@@ -266,7 +266,7 @@ If POSITION is nil, use point."
 You are a code completion assistant. Complete the code at █CURSOR█, inserting your response strictly between █START_COMPLETION█ and █END_COMPLETION█.
 
 REQUIREMENTS:
-1. Output MUST be wrapped in triple backticks (```).
+1. *entire* output **MUST** be wrapped in triple backticks (\`\`\`).
 2. Start with █START_COMPLETION█ and end with █END_COMPLETION█ on their own lines.
 3. Replace █CURSOR█ with the appropriate code; do NOT repeat the █CURSOR█ token.
 4. Do NOT include any code that appears after █END_COMPLETION█ in the input.

--- a/gptel-autocomplete.el
+++ b/gptel-autocomplete.el
@@ -266,7 +266,7 @@ If POSITION is nil, use point."
 You are a code completion assistant. Complete the code at █CURSOR█, inserting your response strictly between █START_COMPLETION█ and █END_COMPLETION█.
 
 REQUIREMENTS:
-1. Output MUST be wrapped in triple backticks (`).
+1. Output MUST be wrapped in triple backticks (```).
 2. Start with █START_COMPLETION█ and end with █END_COMPLETION█ on their own lines.
 3. Replace █CURSOR█ with the appropriate code; do NOT repeat the █CURSOR█ token.
 4. Do NOT include any code that appears after █END_COMPLETION█ in the input.

--- a/gptel-autocomplete.el
+++ b/gptel-autocomplete.el
@@ -63,6 +63,37 @@ Disable idle completion if set to nil."
           (const :tag "Idle completion disabled" nil))
   :group 'gptel-autocomplete)
 
+(defcustom gptel-autocomplete-system-prompt "/no_think
+You are a code completion assistant. Complete the code at █CURSOR█.
+
+REQUIREMENTS:
+1. Output **MUST** be wrapped between █START_COMPLETION█ and █END_COMPLETION█ lines.
+2. Do not repeat the cursor or surrounding code.
+3. Be minimal (1-20 lines max, usually a single line).
+
+Example:
+Input:
+```
+function foo(a, b) {
+█START_COMPLETION█
+    if (a < b) █CURSOR█
+█END_COMPLETION█
+}
+```
+Output:
+```
+█START_COMPLETION█
+    if (a < b) {
+        return a;
+    }
+    return b;
+█END_COMPLETION█
+```
+"
+  "System prompt used for code completion requests."
+  :type 'string
+  :group 'gptel-autocomplete)
+
 (defvar gptel--completion-text nil
   "Current GPTel completion text.")
 
@@ -262,33 +293,7 @@ If POSITION is nil, use point."
         (gptel--log "Full prompt:\n%s" prompt))
       (gptel-request
        prompt
-       :system "/no_think
-You are a code completion assistant. Complete the code at █CURSOR█.
-
-REQUIREMENTS:
-1. Output **MUST** be wrapped between █START_COMPLETION█ and █END_COMPLETION█ lines.
-2. Do not repeat the cursor or surrounding code.
-3. Be minimal (1-20 lines max, usually a single line).
-
-Example:
-Input:
-```
-function foo(a, b) {
-█START_COMPLETION█
-    if (a < b) █CURSOR█
-█END_COMPLETION█
-}
-```
-Output:
-```
-█START_COMPLETION█
-    if (a < b) {
-        return a;
-    }
-    return b;
-█END_COMPLETION█
-```
-"
+       :system gptel-autocomplete-system-prompt
        :buffer (current-buffer)
        :position target-point
        :transforms (when gptel-autocomplete-use-context

--- a/gptel-autocomplete.el
+++ b/gptel-autocomplete.el
@@ -266,7 +266,7 @@ If POSITION is nil, use point."
 You are a code completion assistant. Complete the code at █CURSOR█, inserting your response strictly between █START_COMPLETION█ and █END_COMPLETION█.
 
 REQUIREMENTS:
-1. Output MUST be wrapped in triple backticks (=).
+1. Output MUST be wrapped in triple backticks (`).
 2. Start with █START_COMPLETION█ and end with █END_COMPLETION█ on their own lines.
 3. Replace █CURSOR█ with the appropriate code; do NOT repeat the █CURSOR█ token.
 4. Do NOT include any code that appears after █END_COMPLETION█ in the input.

--- a/gptel-autocomplete.el
+++ b/gptel-autocomplete.el
@@ -263,82 +263,31 @@ If POSITION is nil, use point."
       (gptel-request
        prompt
        :system "/no_think
-You are a code completion assistant integrated into a code editor.
+You are a code completion assistant. Complete the code at █CURSOR█, inserting your response strictly between █START_COMPLETION█ and █END_COMPLETION█.
 
-Complete the code at the cursor position █CURSOR█. The █START_COMPLETION█ and █END_COMPLETION█ \
-markers indicate the exact region where your completion should be inserted, and you should only \
-complete code in that one specific region.
+REQUIREMENTS:
+1. Output MUST be wrapped in triple backticks (=).
+2. Start with █START_COMPLETION█ and end with █END_COMPLETION█ on their own lines.
+3. Replace █CURSOR█ with the appropriate code; do NOT repeat the █CURSOR█ token.
+4. Do NOT include any code that appears after █END_COMPLETION█ in the input.
+5. Be MINIMAL: 1-20 lines max. Most responses should be a single line.
 
-RESPONSE REQUIREMENTS:
-1. Response should be contained within code triple backticks (```)
-2. MUST start with █START_COMPLETION█ on its own line
-3. MUST end with █END_COMPLETION█ on its own line
-4. Complete the line containing █CURSOR█ (replacing █CURSOR█ with appropriate code)
-5. Do NOT include any code that appears after █END_COMPLETION█ in the input text
-6. Add any additional lines that logically follow between the markers
-7. If only █CURSOR█ is present in the completion section, generate new lines that follow \
-from the code before █START_COMPLETION█ (do NOT repeat the █CURSOR█ token)
-8. Generate a MINIMAL response (between 1-20 lines, the shorter and higher-confidence the \
-better; MOST of your responses will JUST BE ONE LINE)
-
-Example input:
+Example:
+Input:
 ```
 function foo(a, b) {
 █START_COMPLETION█
     if (a < b) █CURSOR█
 █END_COMPLETION█
 }
-
-function bar() {
-    console.log('bar');
-}
 ```
-
-Example correct output:
+Output:
 ```
 █START_COMPLETION█
     if (a < b) {
         return a;
     }
     return b;
-█END_COMPLETION█
-```
-
-Example WRONG output (do NOT do this; never provide output after end completion marker):
-```
-█START_COMPLETION█
-    if (a < b) {
-        return a;
-    }
-    return b;
-█END_COMPLETION█
-}
-
-function bar() {
-    console.log('bar');
-}
-```
-
-Example input:
-```
-function foo(a, b) {
-█START_COMPLETION█
-    █CURSOR█
-█END_COMPLETION█
-}
-```
-
-Example correct output:
-```
-█START_COMPLETION█
-    return a < b;
-█END_COMPLETION█
-```
-
-Example WRONG output (do NOT do this; never repeat the cursor token):
-```
-█START_COMPLETION█
-    █CURSOR█
 █END_COMPLETION█
 ```
 "


### PR DESCRIPTION
Hello, I've been trying to improve the speed of local models for my personal use, and one thing I noticed was that the prompt was too long.

I've made adjustments to make it shorten.

Testing with local models (gemma4-E4B, Qwen3.5:9b, Qwen3-coder, etc.) yielded the same results while improving response time.